### PR TITLE
Fix instability of extractor

### DIFF
--- a/src/JobExecutor.ts
+++ b/src/JobExecutor.ts
@@ -24,7 +24,6 @@ import { JobStatus } from './domains/JobStatus';
 import { Job } from './entity/Job';
 import { basename } from "path";
 import { JobApplication } from './JobApplication';
-import { promisify } from 'util';
 import { FileManageService } from './services/FileManageService';
 import { CMD_CANCEL, CMD_PAUSE, CommandMessage } from './domains/CommandMessage';
 import { JobRepository } from './repository/JobRepository';

--- a/src/processors/LocalExtractProcessor.ts
+++ b/src/processors/LocalExtractProcessor.ts
@@ -57,21 +57,11 @@ export class LocalExtractProcessor implements VideoProcessor {
         action.videoFilePath = this._fileManager.getLocalPath(jobMessage.videoFile.filename, jobMessage.id);
         const outputFilename = action.outputFilename || vertex.id;
         vertex.outputPath = this._fileManager.getLocalPath(outputFilename, jobMessage.id);
-        try {
-            if (!await this._fileManager.checkExists(jobMessage.videoFile.filename, jobMessage.id)) {
-                await this._fileManager.downloadFile(jobMessage.videoFile, jobMessage.downloadAppId, jobMessage.id);
+        action.otherFilePaths = [];
+        if (jobMessage.otherFiles && jobMessage.otherFiles.length > 0) {
+            for (const remoteFile of jobMessage.otherFiles) {
+                action.otherFilePaths.push(this._fileManager.getLocalPath(remoteFile.filename, jobMessage.id));
             }
-            action.otherFilePaths = [];
-            if (jobMessage.otherFiles && jobMessage.otherFiles.length > 0) {
-                for (const remoteFile of jobMessage.otherFiles) {
-                    action.otherFilePaths.push(this._fileManager.getLocalPath(remoteFile.filename, jobMessage.id));
-                    if (!await this._fileManager.checkExists(remoteFile.filename, jobMessage.id)) {
-                        await this._fileManager.downloadFile(remoteFile, jobMessage.downloadAppId, jobMessage.id);
-                    }
-                }
-            }
-        } catch (err) {
-            logger.error(err);
         }
     }
 

--- a/src/processors/LocalExtractProcessor.ts
+++ b/src/processors/LocalExtractProcessor.ts
@@ -81,14 +81,13 @@ export class LocalExtractProcessor implements VideoProcessor {
         const cmd = await extractor.extractCMD();
         if (!cmd) {
             // if cmd is null, we only need to copy source file to our outputPath
-            if (extractAction.extractFrom !== ExtractSource.VideoFile) {
+            if (extractor.getInputPath() !== vertex.outputPath) {
                 if(!extractor.getInputPath()) {
                     throw new Error('inputPath of extractor is null when ExtractSource is not VideoFile');
                 }
                 await this._fileManager.localCopy(extractor.getInputPath(), vertex.outputPath);
-            } else {
-                await this._fileManager.localCopy(extractAction.videoFilePath, vertex.outputPath);
             }
+            // if input path and output path is equal, do nothing.
         } else {
             await this.runCommand(cmd, vertex.outputPath);
         }

--- a/src/processors/extractors/FileExtractor.ts
+++ b/src/processors/extractors/FileExtractor.ts
@@ -44,10 +44,10 @@ export class FileExtractor implements Extractor {
         this.action = this.vertex.action as ExtractAction;
     }
     public async extractCMD(): Promise<string[] | null> {
-        // just copy video file
+        // just do nothing
         if (this.action.extractFrom === ExtractSource.VideoFile && this.action.extractTarget === ExtractTarget.KeepContainer) {
             this.inputPath = this.action.videoFilePath;
-            this.vertex.outputPath = this.vertex.outputPath + extname(this.inputPath);
+            this.vertex.outputPath = this.inputPath;
             return null;
         }
 
@@ -92,11 +92,9 @@ export class FileExtractor implements Extractor {
         }
 
         if (!this.inputPath) {
-            this.vertex.outputPath = this.vertex.outputPath + extname(this.inputPath);
-        } else {
             throw new Error('FileExtractor cannot find a file that match any of the conditions');
         }
-
+        this.vertex.outputPath = this.inputPath;
         return null;
     }
 


### PR DESCRIPTION
Sometimes a file extractor copied a file that is smaller than original file.
Solve this issue with two changes:
- FileExtractor has output and input path equal, while LocalExtractProcessor will do nothing when outputPath equals to inputPath.
- Move file downloads from processor.prepare to JobManager before start. this can avoid race condition.