### PR TITLE
Add Convert Video File Support

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -13,6 +13,8 @@ amqpUrl: ''
 # the remote url will be replaced with host defined in the mapping. there is no default value, if appid is not found,
 # no replacement will occur.
 appIdHostMap:
+  # main_site is for downloading files from the main website (currently albireo)
+  main_site: "http://localhost:8000/"
   test_download_manager: "http://localhost:8000/"
 
 # Config Below is for JobExecutor

--- a/src/JobExecutor.ts
+++ b/src/JobExecutor.ts
@@ -234,6 +234,9 @@ export class JobExecutor implements JobApplication {
         try {
             await this.currentJM.start(job.id, this.id, resume);
         } catch (error) {
+            job.status = JobStatus.UnrecoverableError;
+            await this._databaseService.getJobRepository().save(job);
+            await this.finalizeJM();
             logger.error(error);
             this._sentry.capture(error);
         }

--- a/src/JobScheduler.ts
+++ b/src/JobScheduler.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 IROHA LAB
+ * Copyright 2023 IROHA LAB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -125,9 +125,13 @@ export class JobScheduler implements JobApplication {
                         appliedRule = rule;
                         break;
                     }
-                    if (await this.checkConditionMatch(rule.condition, msg)) {
-                        appliedRule = rule;
-                        break;
+                }
+                if (!appliedRule) {
+                    for (const rule of rules) {
+                        if (await this.checkConditionMatch(rule.condition, msg)) {
+                            appliedRule = rule;
+                            break;
+                        }
                     }
                 }
             }

--- a/src/WebServer.ts
+++ b/src/WebServer.ts
@@ -24,6 +24,7 @@ import { API_SERVER, bootstrap } from './api-service/bootstrap';
 import { Server } from 'http';
 import { hostname } from 'os';
 import {
+    DOWNLOAD_MESSAGE_EXCHANGE,
     RabbitMQService,
     Sentry,
     SentryImpl,
@@ -55,9 +56,10 @@ const rabbitMQService = container.get<RabbitMQService>(TYPES.RabbitMQService);
 let webServer: Server;
 
 databaseService.start()
-    .then(() => {
+    .then(async () => {
         if (startAs === API_SERVER) {
-            return rabbitMQService.initPublisher(VIDEO_MANAGER_EXCHANGE, 'direct', VIDEO_MANAGER_COMMAND);
+            await rabbitMQService.initPublisher(DOWNLOAD_MESSAGE_EXCHANGE, 'direct');
+            return await rabbitMQService.initPublisher(VIDEO_MANAGER_EXCHANGE, 'direct', VIDEO_MANAGER_COMMAND);
         }
     })
     .then(() => {

--- a/src/domains/ConvertMessage.ts
+++ b/src/domains/ConvertMessage.ts
@@ -14,17 +14,9 @@
  * limitations under the License.
  */
 
-import { BaseProfile } from './BaseProfile';
-import { ConvertAction } from '../../domains/ConvertAction';
+import { DownloadMQMessage } from '@irohalab/mira-shared';
 
-export class ContainerOnlyProfile extends BaseProfile {
-    public static profileName = 'container_only';
-
-    constructor(action: ConvertAction, fontsDir: string) {
-        super(action, fontsDir);
-    }
-
-    public getCommandArgs(): Promise<string[]> {
-        return Promise.resolve([...this.getInputCommandArgs(), '-c:v', 'copy', '-c:a', 'copy', '-strict', '-2']);
-    }
+export class ConvertMessage extends DownloadMQMessage {
+    public downloadManagerId = 'main_site';
+    public downloadTaskId = null;
 }

--- a/src/services/FileManageService.ts
+++ b/src/services/FileManageService.ts
@@ -52,21 +52,20 @@ export class FileManageService {
 
     public getFileUrlOrLocalPath(remoteFile: RemoteFile, appId: string): RemoteFile {
         const idHostMap = this._configManager.appIdHostMap();
-        const host = idHostMap[appId];
+        const host = appId ? idHostMap[appId]: null;
         const convertedRemoteFile =  new RemoteFile();
         convertedRemoteFile.filename = remoteFile.filename;
         if (host) {
             const hostURLObj = new URL(host);
             if (hostURLObj.hostname === 'localhost') {
                 convertedRemoteFile.fileLocalPath = remoteFile.fileLocalPath;
-            } else {
-                // replace part
-                const fileURLObj = new URL(remoteFile.fileUri);
-                fileURLObj.host = hostURLObj.host;
-                fileURLObj.protocol = hostURLObj.protocol;
-                fileURLObj.pathname = FileManageService.trimEndSlash(hostURLObj.pathname) + fileURLObj.pathname;
-                convertedRemoteFile.fileUri = fileURLObj.toString();
             }
+            // replace part
+            const fileURLObj = new URL(remoteFile.fileUri);
+            fileURLObj.host = hostURLObj.host;
+            fileURLObj.protocol = hostURLObj.protocol;
+            fileURLObj.pathname = FileManageService.trimEndSlash(hostURLObj.pathname) + fileURLObj.pathname;
+            convertedRemoteFile.fileUri = fileURLObj.toString();
         } else {
             convertedRemoteFile.fileUri = remoteFile.fileUri;
         }


### PR DESCRIPTION
- Add API to create a ConvertMessage which is a DownloadMessage with a special DownloadAppId, and null DownloadTaskId,
- Fix bugs in ContainerOnlyProfile
- Fix bugs in JobScheduler to make sure the VideoFile-specific rule is always selected.
- Fix JobManager silently failed to download the files, if the download file failed, the job will fail.
- Refactor JobController to make it use BaseHttpController and its utilities.