### PR TITLE
Add filemapping support for FileExtractor

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
    "license": "Apache-2.0",
    "dependencies": {
       "@cloudamqp/amqp-client": "^2.1.0",
-      "@irohalab/mira-shared": "^3.3.1",
+      "@irohalab/mira-shared": "^3.5.0",
       "@mikro-orm/core": "^5.5.3",
       "@mikro-orm/migrations": "^5.5.3",
       "@mikro-orm/postgresql": "^5.5.3",

--- a/src/JobScheduler.ts
+++ b/src/JobScheduler.ts
@@ -215,6 +215,7 @@ export class JobScheduler implements JobApplication {
         jobMessage.actions = appliedRule.actions;
         jobMessage.videoFile = msg.videoFile;
         jobMessage.otherFiles = msg.otherFiles;
+        jobMessage.fileMapping = msg.fileMapping;
         jobMessage.downloadAppId = msg.downloadManagerId;
         jobMessage.downloadTaskId = msg.downloadTaskId;
         await this.newJob(jobMessage);

--- a/src/domains/ExtractSource.ts
+++ b/src/domains/ExtractSource.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 IROHA LAB
+ * Copyright 2023 IROHA LAB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,5 +16,6 @@
 
 export enum ExtractSource {
     VideoFile = 'VideoFile',
+    Archive = 'Archive',
     OtherFiles = 'OtherFiles'
 }

--- a/src/domains/JobMessage.ts
+++ b/src/domains/JobMessage.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 IROHA LAB
+ * Copyright 2023 IROHA LAB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 import { MQMessage, RemoteFile } from '@irohalab/mira-shared';
 import { ActionMap } from './ActionMap';
+import { FileMapping } from '@irohalab/mira-shared/domain/FileMapping';
 
 export class JobMessage implements MQMessage {
     public id: string;
@@ -25,6 +26,7 @@ export class JobMessage implements MQMessage {
     public actions: ActionMap;
     public videoFile: RemoteFile;
     public otherFiles: RemoteFile[];
+    public fileMapping?: FileMapping;
     public downloadAppId: string;
     public downloadTaskId: string;
     public version: string = '2';

--- a/src/entity/Vertex.ts
+++ b/src/entity/Vertex.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 IROHA LAB
+ * Copyright 2023 IROHA LAB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import { VertexStatus } from '../domains/VertexStatus';
 import { DateTimeType, Entity, EntityRepositoryType, Enum, JsonType, PrimaryKey, Property } from '@mikro-orm/core';
 import { VertexRepository } from '../repository/VertexRepository';
 import { ActionType } from '../domains/ActionType';
+import { FileMapping } from '@irohalab/mira-shared/domain/FileMapping';
 
 @Entity({ customRepository: () => VertexRepository })
 export class Vertex {
@@ -88,6 +89,7 @@ export class Vertex {
     // not serialized
     public videoProcessor: VideoProcessor;
     public upstreamVertexFinished?: boolean[] = [];
+    public fileMapping?: FileMapping;
 
     [EntityRepositoryType]?: VertexRepository;
 }

--- a/src/processors/ExtractorFactory.ts
+++ b/src/processors/ExtractorFactory.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Extractor } from './extractors/Extractor';
+import { Extractor, ExtractorLogger } from './extractors/Extractor';
 import { ExtractAction } from '../domains/ExtractAction';
 import { DefaultExtractor } from './extractors/DefaultExtractor';
 import { interfaces } from 'inversify';
@@ -24,22 +24,23 @@ import { ActionType } from '../domains/ActionType';
 import { FileExtractor } from './extractors/FileExtractor';
 import { SubtitleExtractor } from './extractors/SubtitleExtractor';
 import { AudioExtractor } from './extractors/AudioExtractor';
+import pino from 'pino';
 
-export type ExtractorInitiator = (vertex: Vertex) => Extractor;
+export type ExtractorInitiator = (vertex: Vertex, logger: (log: string, severity: pino.Level) => void) => Extractor;
 
 export function ExtractorFactory(context: interfaces.Context): ExtractorInitiator {
-    return (vertex: Vertex) => {
+    return (vertex: Vertex, logger: ExtractorLogger) => {
         assert(vertex.actionType === ActionType.Extract, "action must be ExtractAction");
         const action = vertex.action as ExtractAction;
         switch (action.extractorId) {
             case DefaultExtractor.Id:
-                return new DefaultExtractor(vertex);
+                return new DefaultExtractor(vertex, logger);
             case FileExtractor.Id:
-                return new FileExtractor(vertex);
+                return new FileExtractor(vertex, logger);
             case SubtitleExtractor.Id:
-                return new SubtitleExtractor(vertex);
+                return new SubtitleExtractor(vertex, logger);
             case AudioExtractor.Id:
-                return new AudioExtractor(vertex);
+                return new AudioExtractor(vertex, logger);
             default:
                 throw new Error('No Extractor found for Id ' + action.extractorId);
         }

--- a/src/processors/extractors/AudioExtractor.ts
+++ b/src/processors/extractors/AudioExtractor.ts
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-import { Extractor } from './Extractor';
+import { Extractor, ExtractorLogger } from './Extractor';
 import { Vertex } from '../../entity/Vertex';
 import { ExtractAction } from '../../domains/ExtractAction';
 import { getStreamsWithFfprobe } from '../../utils/VideoProber';
-import { getStdLogger } from '../../utils/Logger';
-
-const logger = getStdLogger();
 
 /**
  * describe how to find a track based ffprobe track properties
@@ -50,7 +47,7 @@ export class AudioExtractor implements Extractor {
     public static Id = 'Audio';
     public action: ExtractAction;
     private inputPath: string;
-    constructor(private vertex: Vertex) {
+    constructor(private vertex: Vertex, public logger: ExtractorLogger) {
         this.action = this.vertex.action as ExtractAction;
         this.inputPath = this.action.videoFilePath;
     }
@@ -120,7 +117,7 @@ export class AudioExtractor implements Extractor {
         if (CODE_NAME_EXT_MAPPING.hasOwnProperty(codeName)) {
             return CODE_NAME_EXT_MAPPING[codeName];
         } else {
-            logger.warn(`Code Name: ${codeName} has no matched file extension name, will use default .vtt`);
+            this.logger(`Code Name: ${codeName} has no matched file extension name, will use default .vtt`, 'warn');
             return '.vtt';
         }
     }

--- a/src/processors/extractors/DefaultExtractor.ts
+++ b/src/processors/extractors/DefaultExtractor.ts
@@ -15,7 +15,7 @@
  */
 
 import { ExtractTarget } from '../../domains/ExtractTarget';
-import { Extractor } from './Extractor';
+import { Extractor, ExtractorLogger } from './Extractor';
 import { ExtractAction } from '../../domains/ExtractAction';
 import { ExtractSource } from '../../domains/ExtractSource';
 import { extname } from 'path';
@@ -35,7 +35,7 @@ export class DefaultExtractor implements Extractor {
     public inputPath: string;
     public streamsInfo: any[];
     public action: ExtractAction;
-    constructor(public vertex: Vertex) {
+    constructor(public vertex: Vertex, public logger: ExtractorLogger) {
         this.inputPath = null;
         this.action = vertex.action as ExtractAction;
     }

--- a/src/processors/extractors/Extractor.ts
+++ b/src/processors/extractors/Extractor.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 IROHA LAB
+ * Copyright 2023 IROHA LAB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import pino from 'pino';
+
 export interface Extractor {
     /**
      * generate a string being used as ffmpeg arguments.
@@ -26,4 +28,11 @@ export interface Extractor {
      * the inputPath to process with, could be null
      */
     getInputPath(): string|null;
+
+    /**
+     * register a logger that print log to ExtractProcessor
+     */
+    logger: ExtractorLogger;
 }
+
+export type ExtractorLogger = (log: string, severity: pino.Level) => void;

--- a/src/processors/extractors/FileExtractor.ts
+++ b/src/processors/extractors/FileExtractor.ts
@@ -14,20 +14,38 @@
  * limitations under the License.
  */
 
-import { Extractor } from './Extractor';
+import { Extractor, ExtractorLogger } from './Extractor';
 import { Vertex } from '../../entity/Vertex';
 import { ExtractAction } from '../../domains/ExtractAction';
 import { ExtractSource } from '../../domains/ExtractSource';
 import { ExtractTarget } from '../../domains/ExtractTarget';
-import { extname } from 'path';
+import { basename, dirname, extname, join } from 'path';
 import { AUDIO_FILE_EXT, SUBTITLE_EXT, VIDEO_FILE_EXT } from '../../domains/FilenameExtensionConstants';
+import { spawn } from 'child_process';
+import { mkdir, readdir } from 'fs/promises';
+import { nanoid } from 'nanoid';
+import pino from 'pino';
 
 const DEFAULT_REGEX = /(?:\.sc\.|\.tc\.|简体|繁體)/;
+
+const DEFAULT_EPS_REGEX = [
+    /第(\d+)話/i,
+    /第(\d+)话/i,
+    /\[(\d+)(?:v\d)?(?:\s?END)?\]/i,
+    /\s(\d{2,})\s/, /\s(\d+)$/i,
+    /【(\d+)(?:v\d)?(?:\s?END)?】/i,
+    /[.\s]Ep(?:\s)?(\d+)[.\s]/i,
+    /第(\d+)回/i,
+    /\.S\d{1,2}E(\d{1,2})\./i,
+    /'第(\d+)集/i
+];
+
+const COMMAND_TIMEOUT = 5000;
 
 /**
  * the hint must be a regex
  */
-type ExtraData = { fileNameHint: string, fileExtNameHint: string };
+type ExtraData = { fileNameHint: string, archiveFileNameHint: string };
 
 /**
  * Find a file from files that matches certain criteria
@@ -39,7 +57,7 @@ export class FileExtractor implements Extractor {
     public action: ExtractAction;
     private inputPath: string;
 
-    constructor(public vertex: Vertex) {
+    constructor(public vertex: Vertex, public logger: ExtractorLogger) {
         this.inputPath = null;
         this.action = this.vertex.action as ExtractAction;
     }
@@ -51,44 +69,10 @@ export class FileExtractor implements Extractor {
             return null;
         }
 
-        // find from actions.otherFilePaths
-        this.inputPath = this.findFileByHint();
-
-        // if not found by hint, try to find by type
-        let fileExtName: string;
-        if (!this.inputPath) {
-            switch(this.action.extractTarget) {
-                case ExtractTarget.AudioStream:
-                    for (const filePath of this.action.otherFilePaths) {
-                        fileExtName = extname(filePath);
-                        if (AUDIO_FILE_EXT.includes(fileExtName)) {
-                            this.inputPath = filePath;
-                            break;
-                        }
-                    }
-                    break;
-                case ExtractTarget.Subtitle:
-                    for (const filePath of this.action.otherFilePaths) {
-                        fileExtName = extname(filePath);
-                        if (SUBTITLE_EXT.includes(fileExtName)) {
-                            this.inputPath = filePath;
-                            break;
-                        }
-                    }
-                    break;
-                case ExtractTarget.KeepContainer:
-                    // in this case, KeepContainer means select video file
-                    for (const filePath of this.action.otherFilePaths) {
-                        fileExtName = extname(filePath);
-                        if (VIDEO_FILE_EXT.includes(fileExtName)) {
-                            this.inputPath = filePath;
-                            break;
-                        }
-                    }
-                    break;
-                default:
-                    throw new Error('ExtractTarget not supported: ' + this.action.extractTarget);
-            }
+        if (this.action.extractFrom === ExtractSource.Archive) {
+            this.inputPath = await this.findFromArchive();
+        } else {
+            this.inputPath = this.findInputPath(this.action.otherFilePaths);
         }
 
         if (!this.inputPath) {
@@ -102,31 +86,180 @@ export class FileExtractor implements Extractor {
         return this.inputPath;
     }
 
-    private findFileByHint(): string {
+    private findInputPath(fileList: string[]): string {
+        // find from actions.otherFilePaths
+        let inputPath = this.findFileByHint(fileList);
+
+        // if not found by hint, try to find by type
+        let fileExtName: string;
+        if (!inputPath) {
+            switch(this.action.extractTarget) {
+                case ExtractTarget.AudioStream:
+                    for (const filePath of this.action.otherFilePaths) {
+                        fileExtName = extname(filePath);
+                        if (AUDIO_FILE_EXT.includes(fileExtName)) {
+                            inputPath = filePath;
+                            break;
+                        }
+                    }
+                    break;
+                case ExtractTarget.Subtitle:
+                    inputPath = this.findSubtitleFile(fileList);
+                    break;
+                case ExtractTarget.KeepContainer:
+                    // in this case, KeepContainer means select video file
+                    for (const filePath of fileList) {
+                        fileExtName = extname(filePath);
+                        if (VIDEO_FILE_EXT.includes(fileExtName)) {
+                            inputPath = filePath;
+                            break;
+                        }
+                    }
+                    break;
+                default:
+                    throw new Error('ExtractTarget not supported: ' + this.action.extractTarget);
+            }
+        }
+        return inputPath;
+    }
+
+    private findFileByHint(fileList: string[]): string {
         let fileNameHint: string;
-        let fileExtNameHint: string;
         if (this.action.extraData) {
             const extraData = this.action.extraData as ExtraData;
             fileNameHint = extraData.fileNameHint;
-            fileExtNameHint= extraData.fileExtNameHint
         }
 
         let hintRegex: RegExp;
         if (fileNameHint) {
-            hintRegex = new RegExp(fileNameHint);
-            for (const filePath of this.action.otherFilePaths) {
-                if (hintRegex.test(filePath)) {
-                    return filePath;
+            hintRegex = new RegExp(fileNameHint, 'i');
+            let resultPath = null;
+            // for subtitle hintRegex, a named capture group must be used and
+            // there must be a group named EPS_NO to capture the episode number in the filename.
+            if (this.vertex.fileMapping && this.action.extractTarget === ExtractTarget.Subtitle) {
+                const epsNo = this.vertex.fileMapping.episodeNo + '';
+                for(const filePath of fileList) {
+                    const m = filePath.match(hintRegex);
+                    if (m && m.groups && m.groups.EPS_NO) {
+                        const matchedNum = m.groups.EPS_NO;
+                        if (matchedNum === epsNo.padStart(matchedNum.length, '0')) {
+                            resultPath = filePath;
+                            break;
+                        }
+                    }
                 }
             }
-        } else if (fileExtNameHint) {
-            hintRegex = new RegExp(fileExtNameHint);
-            for (const filePath of this.action.otherFilePaths) {
-                if (hintRegex.test(filePath)) {
-                    return filePath;
+            if (!resultPath) {
+                for (const filePath of fileList) {
+                    if (hintRegex.test(filePath)) {
+                        resultPath = filePath;
+                        break;
+                    }
+                }
+            }
+            return resultPath;
+        }
+        return null;
+    }
+
+    private findSubtitleFile(fileList: string[]): string {
+        let fileExtName: string;
+        let fileBaseName: string;
+        let epsNo = null;
+        if (this.vertex.fileMapping) {
+            epsNo = this.vertex.fileMapping.episodeNo + '';
+        }
+        let inputPath = null;
+        for (const filePath of fileList) {
+            if (inputPath) {
+                break;
+            }
+            fileExtName = extname(filePath);
+            fileBaseName = basename(filePath);
+            if (SUBTITLE_EXT.includes(fileExtName)) {
+                if (epsNo !== null) {
+                    for (const reg of DEFAULT_EPS_REGEX) {
+                        const m = fileBaseName.match(reg);
+                        if (m) {
+                            const matchedNumber = m[1];
+                            if (matchedNumber === epsNo.padStart(matchedNumber.length, '0')) {
+                                inputPath = filePath;
+                                break;
+                            }
+                        }
+                    }
+                } else {
+                    inputPath = filePath;
                 }
             }
         }
-        return null;
+        return inputPath;
+    }
+
+    private async findFromArchive(): Promise<string> {
+        let inputPath: string = null;
+        let archiveFileNameHint: string;
+        if (this.action.extraData) {
+            const extraData = this.action.extraData as ExtraData;
+            archiveFileNameHint = extraData.archiveFileNameHint;
+        }
+        let hintRegex: RegExp;
+        let archiveFilePath: string;
+        if (archiveFileNameHint) {
+            hintRegex = new RegExp(archiveFileNameHint, 'i');
+            for (const filePath of this.action.otherFilePaths) {
+                if (hintRegex.test(filePath)) {
+                    archiveFilePath = filePath;
+                    break;
+                }
+            }
+        }
+        if (archiveFilePath) {
+            // in case we need to use another archive extractor, we can add switch based on extension name.
+            inputPath = await this.getInputPathByUnRar(archiveFilePath);
+        }
+        return inputPath;
+    }
+
+    private async getInputPathByUnRar(archiveFilePath): Promise<string> {
+        const destPath = join(dirname(archiveFilePath), nanoid(5));
+        try {
+            await mkdir(destPath, {
+                recursive: true,
+            });
+        } catch (ex) {
+            this.logger(ex, 'error');
+            return null;
+        }
+
+        await new Promise((resolve, reject) => {
+            try {
+                const child = spawn('unrar', ['e', archiveFilePath, destPath], {
+                    timeout: COMMAND_TIMEOUT,
+                });
+                child.on('close', (code) => {
+                    if (code !== 0) {
+                        reject();
+                        return;
+                    }
+                    resolve('');
+                });
+            } catch (exception) {
+                reject(exception);
+            }
+        });
+        try {
+            const archiveFiles = await readdir(destPath);
+            const contentFilesAbsPath: string[] = [];
+            this.logger('archive content list:', 'info');
+            for (const af of archiveFiles) {
+                this.logger(af, 'info');
+                contentFilesAbsPath.push(join(destPath, af));
+            }
+            return this.findInputPath(contentFilesAbsPath);
+        } catch (ex) {
+            this.logger(ex, 'error');
+            return null;
+        }
     }
 }

--- a/src/processors/extractors/SubtitleExtractor.ts
+++ b/src/processors/extractors/SubtitleExtractor.ts
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-import { Extractor } from './Extractor';
+import { Extractor, ExtractorLogger } from './Extractor';
 import { ExtractAction } from '../../domains/ExtractAction';
 import { Vertex } from '../../entity/Vertex';
 import { getStreamsWithFfprobe } from '../../utils/VideoProber';
-import { getStdLogger } from '../../utils/Logger';
-
-const logger = getStdLogger();
 
 /**
  * describe how to find a track based ffprobe track properties
@@ -51,7 +48,7 @@ export class SubtitleExtractor implements Extractor {
     public action: ExtractAction;
     private inputPath: string;
 
-    constructor(private vertex: Vertex) {
+    constructor(private vertex: Vertex, public logger: ExtractorLogger) {
         this.action = this.vertex.action as ExtractAction;
         this.inputPath = this.action.videoFilePath;
     }
@@ -115,7 +112,7 @@ export class SubtitleExtractor implements Extractor {
         if (CODE_NAME_EXT_MAPPING.hasOwnProperty(codeName)) {
             return CODE_NAME_EXT_MAPPING[codeName];
         } else {
-            logger.warn(`Code Name: ${codeName} has no matched file extension name, will use default .vtt`);
+            this.logger(`Code Name: ${codeName} has no matched file extension name, will use default .vtt`, 'warn');
             return '.vtt';
         }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,15 @@
 # yarn lockfile v1
 
 
+"@acuminous/bitsyntax@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@acuminous/bitsyntax/-/bitsyntax-0.1.2.tgz#e0b31b9ee7ad1e4dd840c34864327c33d9f1f653"
+  integrity sha512-29lUK80d1muEQqiUsSo+3A0yP6CdspgC95EnKBMi22Xlwt79i/En4Vr67+cXhU+cZjbti3TgGGC5wy1stIywVQ==
+  dependencies:
+    buffer-more-ints "~1.0.0"
+    debug "^4.3.4"
+    safe-buffer "~5.1.2"
+
 "@babel/code-frame@^7.0.0":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.13.tgz#dcfc826beef65e75c50e21d3837d7d95798dd658"
@@ -48,16 +57,16 @@
   dependencies:
     "@cspotcode/source-map-consumer" "0.8.0"
 
-"@irohalab/mira-shared@^3.3.1":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@irohalab/mira-shared/-/mira-shared-3.3.1.tgz#21cb45670f490466c8761714a3fe144571c283de"
-  integrity sha512-PnyoQYRThSokw3+F50dUadM6EbDGJ/gEl+KEVEccZNVFfukNXNoXAyAw7X/GLI7q4mDuLVrtHnr5byaniN2O7g==
+"@irohalab/mira-shared@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@irohalab/mira-shared/-/mira-shared-3.5.0.tgz#4d597c116da2450c5d2f922cf34bf60d736de2f4"
+  integrity sha512-ParorWs2DrJvhBdt6sniarol3fKxB4mENotAaFtVizldfZvOT1AP2u3z18RU653G4zbMwN4Vo0jf+oC0CaEMAw==
   dependencies:
     "@cloudamqp/amqp-client" "^2.1.0"
     "@mikro-orm/core" "^5.5.3"
     "@mikro-orm/postgresql" "^5.5.3"
     "@sentry/node" "^7.0.0"
-    amqplib "^0.7.1"
+    amqplib "^0.10.3"
     inversify "^5.0.5"
     inversify-binding-decorators "^4.0.0"
     inversify-logger-middleware "^3.1.0"
@@ -429,6 +438,16 @@ aggregate-error@^4.0.0:
   dependencies:
     clean-stack "^4.0.0"
     indent-string "^5.0.0"
+
+amqplib@^0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/amqplib/-/amqplib-0.10.3.tgz#e186a2f74521eb55ec54db6d25ae82c29c1f911a"
+  integrity sha512-UHmuSa7n8vVW/a5HGh2nFPqAEr8+cD4dEZ6u9GjP91nHfr1a54RyAKyra7Sb5NH7NBKOUlyQSMXIp0qAixKexw==
+  dependencies:
+    "@acuminous/bitsyntax" "^0.1.2"
+    buffer-more-ints "~1.0.0"
+    readable-stream "1.x >=1.1.9"
+    url-parse "~1.5.10"
 
 amqplib@^0.7.1:
   version "0.7.1"
@@ -3153,7 +3172,7 @@ unpipe@1.0.0, unpipe@~1.0.0:
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
 
-url-parse@~1.5.1:
+url-parse@~1.5.1, url-parse@~1.5.10:
   version "1.5.10"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
   integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==


### PR DESCRIPTION
- Add FIleMapping into JobMessage
- For job which has fileMapping, when finding the subtitles from otherFiles or Archive files, use the episode number from the file mapping to match the number from the filename or using the fileNameHint regular expression to find the correct subtitle file.
- add handler for LocalExtractProcessor in order for extractors to write log into the vertex log.