### PR TITLE
Set default storage_type to Filesystem for backward compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "mira-video-manager",
-   "version": "1.8.0",
+   "version": "1.8.1",
    "description": "Video Process for mira project",
    "main": "index.js",
    "scripts": {

--- a/src/utils/ConfigManagerImpl.ts
+++ b/src/utils/ConfigManagerImpl.ts
@@ -81,7 +81,7 @@ export class ConfigManagerImpl implements ConfigManager {
     }
 
     public storageType(): 'S3' | 'Filesystem' {
-        return this._config.storage_type;
+        return this._config.storage_type ?? 'Filesystem';
     }
 
     public s3Config(): S3ClientConfig {


### PR DESCRIPTION
This pull request includes a minor version bump and a small but important improvement to the configuration handling logic. The main change ensures that the application defaults to using the 'Filesystem' storage type if no storage type is specified in the configuration.

Configuration handling improvement:
* Updated the `storageType` method in `ConfigManagerImpl` to default to `'Filesystem'` if `storage_type` is not set in the configuration.

Other changes:
* Bumped the project version from `1.8.0` to `1.8.1` in `package.json`.