### PR TITLE
Add routing key for download_message_queue and bump version to 1.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "mira-video-manager",
-   "version": "1.8.2",
+   "version": "1.8.3",
    "description": "Video Process for mira project",
    "main": "index.js",
    "scripts": {

--- a/src/JobScheduler.ts
+++ b/src/JobScheduler.ts
@@ -48,7 +48,7 @@ import {
     NORMAL_JOB_KEY,
     VIDEO_JOB_RESULT_KEY,
     VIDEO_JOB_RESULT_QUEUE,
-    VIDEO_MANAGER_COMMAND_EXCHANGE
+    VIDEO_MANAGER_COMMAND_EXCHANGE, KEY_DOWNLOAD_MESSAGE
 } from './TYPES';
 import { JobType } from './domains/JobType';
 import { ValidateAction } from './domains/ValidateAction';
@@ -83,7 +83,7 @@ export class JobScheduler implements JobApplication {
         await this._rabbitmqService.initConsumer(VIDEO_MANAGER_COMMAND_EXCHANGE, 'fanout', JS_COMMAND_QUEUE, '', 1);
         await this._rabbitmqService.initConsumer(VIDEO_MANAGER_EXCHANGE, 'direct', VIDEO_JOB_RESULT_QUEUE, VIDEO_JOB_RESULT_KEY, 1);
         await this._rabbitmqService.initConsumer(JOB_EXCHANGE, 'direct', JOB_QUEUE, NORMAL_JOB_KEY, 1);
-        await this._rabbitmqService.initConsumer(DOWNLOAD_MESSAGE_EXCHANGE, 'direct', DOWNLOAD_MESSAGE_QUEUE);
+        await this._rabbitmqService.initConsumer(DOWNLOAD_MESSAGE_EXCHANGE, 'direct', DOWNLOAD_MESSAGE_QUEUE, KEY_DOWNLOAD_MESSAGE);
         await this._rabbitmqService.initConsumer(JOB_EXCHANGE, 'direct', META_JOB_QUEUE, META_JOB_KEY, 1);
         this._downloadMessageConsumeTag = await this._rabbitmqService.consume(DOWNLOAD_MESSAGE_QUEUE, async (msg) => {
             try {

--- a/src/TYPES.ts
+++ b/src/TYPES.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 IROHA LAB
+ * Copyright 2026 IROHA LAB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ export const VIDEO_JOB_RESULT_QUEUE = 'video_job_result_queue';
 export const JS_COMMAND_QUEUE = 'js_command_queue';
 
 // routing key
+export const KEY_DOWNLOAD_MESSAGE = 'key_download_message'; // TODO: move to mira_shared
 export const NORMAL_JOB_KEY = 'normal_job';
 export const META_JOB_KEY = 'meta_job';
 export const VIDEO_JOB_RESULT_KEY = 'video_job_result_key';


### PR DESCRIPTION
This pull request introduces a minor version bump and updates the RabbitMQ consumer configuration for the download message queue in the `mira-video-manager` project. The main focus is on improving message routing by specifying a routing key for the download message queue, and making a small copyright update.

**Messaging and RabbitMQ configuration:**
* Updated the initialization of the RabbitMQ consumer for `DOWNLOAD_MESSAGE_QUEUE` in `JobScheduler.ts` to include the new `KEY_DOWNLOAD_MESSAGE` routing key, improving message routing specificity.
* Added `KEY_DOWNLOAD_MESSAGE` as a new routing key constant in `TYPES.ts` and included a TODO to move it to `mira_shared` in the future.
* Imported the new `KEY_DOWNLOAD_MESSAGE` constant in `JobScheduler.ts`.

**Versioning and licensing:**
* Bumped the package version from `1.8.2` to `1.8.3` in `package.json` to reflect these updates.
* Updated the copyright year from 2025 to 2026 in `TYPES.ts`.