### PR TITLE
Feat/reconcile unfinished video file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "mira-video-manager",
-   "version": "1.8.5",
+   "version": "1.9.0",
    "description": "Video Process for mira project",
    "main": "index.js",
    "scripts": {

--- a/src/WebServer.ts
+++ b/src/WebServer.ts
@@ -30,7 +30,8 @@ import {
     SentryImpl,
     TYPES,
     VIDEO_MANAGER_COMMAND,
-    VIDEO_MANAGER_EXCHANGE
+    VIDEO_MANAGER_EXCHANGE,
+    VIDEO_MANAGER_GENERAL
 } from '@irohalab/mira-shared';
 import { RascalImpl } from '@irohalab/mira-shared/services/RascalImpl';
 import { getStdLogger } from './utils/Logger';
@@ -60,6 +61,7 @@ databaseService.start()
     .then(async () => {
         if (startAs === API_SERVER) {
             await rabbitMQService.initPublisher(DOWNLOAD_MESSAGE_EXCHANGE, 'direct', KEY_DOWNLOAD_MESSAGE);
+            await rabbitMQService.initPublisher(VIDEO_MANAGER_EXCHANGE, 'direct', VIDEO_MANAGER_GENERAL);
             return await rabbitMQService.initPublisher(VIDEO_MANAGER_COMMAND_EXCHANGE, 'fanout', '');
         }
     })

--- a/src/api-service/bootstrap.ts
+++ b/src/api-service/bootstrap.ts
@@ -28,6 +28,7 @@ import { Server as SocketIOServer } from 'socket.io';
 import { interfaces, InversifySocketServer, TYPE } from 'inversify-socket-utils';
 import { JobLogController } from './socket-controller/JobLogController';
 import { VertexLogController } from './socket-controller/VertexLogController';
+import { JobReconciliationService } from '../services/JobReconciliationService';
 
 export const JOB_EXECUTOR = 'JOB_EXECUTOR';
 export const API_SERVER = 'API_SERVER';
@@ -46,6 +47,7 @@ export function bootstrap(container: Container, startAs: string): HttpServer {
         // tslint:disable-next-line:no-var-requires
         require('./controller/JobController');
 
+        container.bind<JobReconciliationService>(JobReconciliationService).toSelf().inSingletonScope();
         container.bind<interfaces.Controller>(TYPE.Controller).to(JobLogController).whenTargetNamed('JobLogController');
         container.bind<interfaces.Controller>(TYPE.Controller).to(VertexLogController).whenTargetNamed('VertexLogController');
     } else {

--- a/src/api-service/controller/JobController.ts
+++ b/src/api-service/controller/JobController.ts
@@ -24,6 +24,7 @@ import {
     interfaces,
     queryParam,
     request,
+    requestBody,
     requestParam,
     response
 } from 'inversify-express-utils';
@@ -40,6 +41,7 @@ import { CMD_CANCEL, CMD_PAUSE, CMD_RESUME, CommandMessage } from '../../domains
 import { getStdLogger } from '../../utils/Logger';
 import { Job } from '../../entity/Job';
 import { VIDEO_MANAGER_COMMAND_EXCHANGE } from '../../TYPES';
+import { JobReconciliationService } from '../../services/JobReconciliationService';
 
 type Operation = {action: string};
 
@@ -52,7 +54,8 @@ const logger = getStdLogger();
 @controller('/job')
 export class JobController extends BaseHttpController implements interfaces.Controller {
     constructor(@inject(TYPES.DatabaseService) private _databaseService: DatabaseService,
-                @inject(TYPES.RabbitMQService) private _mqService: RabbitMQService) {
+                @inject(TYPES.RabbitMQService) private _mqService: RabbitMQService,
+                private _reconciliationService: JobReconciliationService) {
         super();
     }
 
@@ -64,6 +67,36 @@ export class JobController extends BaseHttpController implements interfaces.Cont
             jobs = await this._databaseService.getJobRepository(true).listJobs(status, bangumiId);
             return this.json({
                 data: jobs,
+                status: 0
+            });
+        } catch (ex) {
+            logger.warn(ex);
+            return JsonResultFactory(500);
+        }
+    }
+
+    /**
+     * Reconcile finished jobs whose completion notification was never delivered
+     * to the streaming platform (e.g. jobs finished while the legacy RPC endpoint
+     * was unavailable). Re-publishes the VideoManagerMessage so the download
+     * manager re-runs its pipeline and emits the download_complete message.
+     *
+     * The request body must provide the `videoFileIds` to reconcile (the UI knows
+     * which video files are still pending), so only the matching finished jobs are
+     * replayed.
+     */
+    @httpPost('/reconcile')
+    public async reconcileFinishedJobs(@requestBody() body: { videoFileIds: string[] }): Promise<IHttpActionResult> {
+        const videoFileIds = body && Array.isArray(body.videoFileIds)
+            ? body.videoFileIds.filter(id => typeof id === 'string' && id.length > 0)
+            : [];
+        if (videoFileIds.length === 0) {
+            return JsonResultFactory(400, { message: 'videoFileIds is required and must be a non-empty array', status: 1 });
+        }
+        try {
+            const result = await this._reconciliationService.reconcileFinishedJobs(videoFileIds);
+            return this.json({
+                data: result,
                 status: 0
             });
         } catch (ex) {

--- a/src/repository/JobRepository.ts
+++ b/src/repository/JobRepository.ts
@@ -48,6 +48,22 @@ export class JobRepository extends BaseEntityRepository<Job> {
         return await this.findOne({ jobExecutorId, id: jobId, status: JobStatus.Running});
     }
 
+    /**
+     * List finished jobs for the given video file ids that haven't been cleaned
+     * yet, so their output vertices and files are still available for
+     * reconciliation (re-notification). Both NORMAL_JOB and META_JOB are
+     * included: video files without a process rule always run as META_JOB.
+     */
+    public async getReconcilableFinishedJobs(videoFileIds: string[]): Promise<Job[]> {
+        return await this.find({
+            $and: [
+                {status: JobStatus.Finished},
+                {cleaned: false},
+                {jobMessage: {videoId: {$in: videoFileIds}}}
+            ]
+        }, {orderBy: {createTime: 'DESC'}});
+    }
+
     public async listJobs(status: string, bangumiId?: string): Promise<Partial<Job>[]> {
         const filterQuery: FilterQuery<Job> = {};
         const findOptions: FindOptions<Job, never, "id" | "jobMessage" | "status" | "createTime" | "startTime" | "finishedTime", never> = {

--- a/src/services/JobReconciliationService.ts
+++ b/src/services/JobReconciliationService.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2026 IROHA LAB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { inject, injectable } from 'inversify';
+import {
+    RabbitMQService,
+    RemoteFile,
+    Sentry,
+    TYPES,
+    VIDEO_MANAGER_EXCHANGE,
+    VIDEO_MANAGER_GENERAL,
+    VideoManagerMessage
+} from '@irohalab/mira-shared';
+import { basename } from 'path';
+import { randomUUID } from 'crypto';
+import { DatabaseService } from './DatabaseService';
+import { ConfigManager } from '../utils/ConfigManager';
+import { Job } from '../entity/Job';
+import { JobType } from '../domains/JobType';
+import { getStdLogger } from '../utils/Logger';
+
+const logger = getStdLogger();
+
+export interface ReconciliationResult {
+    /** number of finished jobs that were re-notified */
+    reconciled: number;
+    /** number of finished jobs that were skipped (e.g. no output files) */
+    skipped: number;
+    /** jobIds/videoIds that were re-notified */
+    jobs: Array<{ jobId: string, videoId: string, bangumiId: string }>;
+}
+
+/**
+ * Re-publishes the VideoManagerMessage for already finished jobs so the download
+ * manager re-runs its post-processing pipeline (which now publishes the
+ * download_complete AMQP message). This is used to recover VideoFiles/Episodes
+ * that never received the original completion notification (e.g. jobs that
+ * finished while the legacy Albireo RPC endpoint was unavailable).
+ *
+ * The caller (UI) provides the specific video file ids to reconcile. Only jobs
+ * that are Finished and not cleaned are eligible, because their output vertices
+ * and files must still be available.
+ */
+@injectable()
+export class JobReconciliationService {
+    constructor(@inject(TYPES.DatabaseService) private _databaseService: DatabaseService,
+                @inject(TYPES.RabbitMQService) private _mqService: RabbitMQService,
+                @inject(TYPES.ConfigManager) private _configManager: ConfigManager,
+                @inject(TYPES.Sentry) private _sentry: Sentry) {
+    }
+
+    public async reconcileFinishedJobs(videoFileIds: string[]): Promise<ReconciliationResult> {
+        const jobRepo = this._databaseService.getJobRepository(true);
+        const vertexRepo = this._databaseService.getVertexRepository();
+        const jobs = await jobRepo.getReconcilableFinishedJobs(videoFileIds);
+
+        const result: ReconciliationResult = { reconciled: 0, skipped: 0, jobs: [] };
+
+        // A video file may have more than one finished job (e.g. reprocessed).
+        // Jobs are ordered by createTime DESC, so keep only the most recent job
+        // per videoId to avoid publishing duplicate messages.
+        const seenVideoIds = new Set<string>();
+
+        for (const job of jobs) {
+            try {
+                const videoId = job.jobMessage.videoId;
+                if (seenVideoIds.has(videoId)) {
+                    continue;
+                }
+                seenVideoIds.add(videoId);
+                const outputVertices = await vertexRepo.getOutputVertices(job.id);
+                const outputPathList = outputVertices.map(vx => vx.outputPath).filter(p => !!p);
+                if (outputPathList.length === 0 || !job.metadata) {
+                    logger.warn(`Skip reconciliation for job ${job.id}: no output files or metadata`);
+                    result.skipped++;
+                    continue;
+                }
+                const msg = this.buildVideoManagerMessage(job, outputPathList);
+                const published = await this._mqService.publish(VIDEO_MANAGER_EXCHANGE, VIDEO_MANAGER_GENERAL, msg);
+                if (published) {
+                    result.reconciled++;
+                    result.jobs.push({ jobId: job.id, videoId: msg.videoId, bangumiId: msg.bangumiId });
+                    logger.info(`Re-published VideoManagerMessage for job ${job.id}, videoId: ${msg.videoId}`);
+                } else {
+                    result.skipped++;
+                    logger.warn(`Failed to publish VideoManagerMessage for job ${job.id}`);
+                }
+            } catch (ex) {
+                result.skipped++;
+                logger.error(ex);
+                this._sentry.capture(ex);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Rebuilds the VideoManagerMessage from a finished job. File URIs are
+     * reconstructed deterministically (no re-upload to S3), matching the URIs
+     * produced by JobExecutor.notifyFinished.
+     */
+    private buildVideoManagerMessage(job: Job, outputPathList: string[]): VideoManagerMessage {
+        const msg = new VideoManagerMessage();
+        msg.id = randomUUID();
+        msg.processedFiles = outputPathList.map((outputPath) => this.toRemoteFile(outputPath, job.jobMessageId));
+
+        const thumbnailPath = this.toRemoteFile(job.metadata.thumbnailPath, job.jobMessageId);
+        const keyframeImagePathList = (job.metadata.keyframeImagePathList || [])
+            .map((p) => this.toRemoteFile(p, job.jobMessageId));
+
+        msg.metadata = Object.assign({}, job.metadata, { thumbnailPath, keyframeImagePathList });
+        msg.jobExecutorId = job.jobExecutorId;
+        msg.bangumiId = job.jobMessage.bangumiId;
+        msg.videoId = job.jobMessage.videoId;
+        msg.downloadTaskId = job.jobMessage.downloadTaskId;
+        msg.isProcessed = job.jobMessage.jobType === JobType.NORMAL_JOB;
+        return msg;
+    }
+
+    private toRemoteFile(localPath: string, jobMessageId: string): RemoteFile {
+        const remoteFile = new RemoteFile();
+        remoteFile.filename = basename(localPath);
+        remoteFile.fileLocalPath = localPath;
+        if (this._configManager.storageType() === 'S3') {
+            remoteFile.fileUri = `s3://${this._configManager.s3Bucket()}/${remoteFile.filename}`;
+        } else {
+            remoteFile.fileUri = this._configManager.getFileUrl(remoteFile.filename, jobMessageId);
+        }
+        return remoteFile;
+    }
+}


### PR DESCRIPTION
This pull request introduces a new feature for reconciling finished jobs that were not properly notified to the streaming platform, along with supporting changes to the API, service layer, and job repository. The main focus is to allow manual re-notification of completed jobs whose completion messages were missed, improving system reliability and recovery.

**New job reconciliation feature:**

* Added a new service, `JobReconciliationService`, which provides logic to re-publish `VideoManagerMessage` events for finished jobs that were not cleaned and whose notifications were missed. This service ensures only the latest job per video file is re-notified and handles error cases gracefully.
* Updated `JobRepository` with a new method `getReconcilableFinishedJobs`, which returns finished and uncleared jobs for a given set of video file IDs, supporting the reconciliation process.

**API and dependency injection updates:**

* Added a new `/job/reconcile` HTTP POST endpoint in `JobController` that accepts a list of video file IDs, invokes the reconciliation service, and returns the result. This endpoint includes input validation and error handling. [[1]](diffhunk://#diff-492018b7454427b7c6f319931b82b963f1aa43080aef9edcdd6d4e5961a975edL55-R58) [[2]](diffhunk://#diff-492018b7454427b7c6f319931b82b963f1aa43080aef9edcdd6d4e5961a975edR78-R107)
* Registered `JobReconciliationService` as a singleton in the DI container during API bootstrap, ensuring it is available for controller injection. [[1]](diffhunk://#diff-b452576ccbe55ee0d7d9774f76dae8f05e0f914a6d8672ae86db7df545498156R31) [[2]](diffhunk://#diff-b452576ccbe55ee0d7d9774f76dae8f05e0f914a6d8672ae86db7df545498156R50)

**Messaging and infrastructure:**

* Updated RabbitMQ publisher initialization to ensure the `VIDEO_MANAGER_EXCHANGE` with the `VIDEO_MANAGER_GENERAL` routing key is ready for reconciliation message publishing. [[1]](diffhunk://#diff-19fd500c28087ca3324ef331071eba3e284cd193e077a6b530b85dff92ca1edcL33-R34) [[2]](diffhunk://#diff-19fd500c28087ca3324ef331071eba3e284cd193e077a6b530b85dff92ca1edcR64)

**Other:**

* Bumped the package version to `1.9.0` to reflect the addition of this new feature.