### PR TITLE
Bugfix/reconcile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "mira-video-manager",
-   "version": "2.0.1",
+   "version": "2.0.2",
    "description": "Video Process for mira project",
    "main": "index.js",
    "scripts": {

--- a/src/WebServer.ts
+++ b/src/WebServer.ts
@@ -35,7 +35,7 @@ import {
 } from '@irohalab/mira-shared';
 import { RascalImpl } from '@irohalab/mira-shared/services/RascalImpl';
 import { getStdLogger } from './utils/Logger';
-import { KEY_DOWNLOAD_MESSAGE, VIDEO_MANAGER_COMMAND_EXCHANGE } from './TYPES';
+import { KEY_DOWNLOAD_MESSAGE, VIDEO_COMPLETE_KEY, VIDEO_MANAGER_COMMAND_EXCHANGE } from './TYPES';
 
 const startAs = process.env.START_AS;
 
@@ -62,6 +62,7 @@ databaseService.start()
         if (startAs === API_SERVER) {
             await rabbitMQService.initPublisher(DOWNLOAD_MESSAGE_EXCHANGE, 'direct', KEY_DOWNLOAD_MESSAGE);
             await rabbitMQService.initPublisher(VIDEO_MANAGER_EXCHANGE, 'direct', VIDEO_MANAGER_GENERAL);
+            await rabbitMQService.initPublisher(VIDEO_MANAGER_EXCHANGE, 'direct', VIDEO_COMPLETE_KEY);
             return await rabbitMQService.initPublisher(VIDEO_MANAGER_COMMAND_EXCHANGE, 'fanout', '');
         }
     })

--- a/src/services/JobReconciliationService.ts
+++ b/src/services/JobReconciliationService.ts
@@ -31,6 +31,7 @@ import { ConfigManager } from '../utils/ConfigManager';
 import { Job } from '../entity/Job';
 import { JobType } from '../domains/JobType';
 import { getStdLogger } from '../utils/Logger';
+import { VIDEO_COMPLETE_KEY } from '../TYPES';
 
 const logger = getStdLogger();
 
@@ -49,6 +50,10 @@ export interface ReconciliationResult {
  * download_complete AMQP message). This is used to recover VideoFiles/Episodes
  * that never received the original completion notification (e.g. jobs that
  * finished while the legacy Albireo RPC endpoint was unavailable).
+ *
+ * The routing key mirrors JobExecutor.notifyFinished: in S3 mode the message is
+ * sent to the video_complete queue of the video manager, otherwise it is sent
+ * with the general video manager routing key.
  *
  * The caller (UI) provides the specific video file ids to reconcile. Only jobs
  * that are Finished and not cleaned are eligible, because their output vertices
@@ -89,7 +94,8 @@ export class JobReconciliationService {
                     continue;
                 }
                 const msg = this.buildVideoManagerMessage(job, outputPathList);
-                const published = await this._mqService.publish(VIDEO_MANAGER_EXCHANGE, VIDEO_MANAGER_GENERAL, msg);
+                const routingKey = this._configManager.storageType() === 'S3' ? VIDEO_COMPLETE_KEY : VIDEO_MANAGER_GENERAL;
+                const published = await this._mqService.publish(VIDEO_MANAGER_EXCHANGE, routingKey, msg);
                 if (published) {
                     result.reconciled++;
                     result.jobs.push({ jobId: job.id, videoId: msg.videoId, bangumiId: msg.bangumiId });


### PR DESCRIPTION
This pull request introduces improved handling for video completion notifications, especially for S3 storage mode, and updates the message routing logic to ensure messages are sent to the correct queue. The main changes include adding a new routing key for video completion, updating publisher initialization, and adjusting the logic in `JobReconciliationService` to use the new routing key when appropriate.

**Message Routing Improvements:**

* Added a new routing key `VIDEO_COMPLETE_KEY` to `TYPES` and updated all relevant imports to support targeted message delivery for video completion events. [[1]](diffhunk://#diff-19fd500c28087ca3324ef331071eba3e284cd193e077a6b530b85dff92ca1edcL38-R38) [[2]](diffhunk://#diff-fcdcfd45b80a7b533332037aaadf60c4150e1e94e0ad2e4ab93c1b54c29f9c71R34)
* Updated the publisher initialization in `WebServer.ts` to register a publisher for `VIDEO_COMPLETE_KEY`, ensuring the system can send messages to the dedicated video completion queue.

**Job Reconciliation Logic:**

* Modified the job reconciliation process in `JobReconciliationService.ts` so that when the storage type is S3, video completion messages are routed using `VIDEO_COMPLETE_KEY`; otherwise, the general routing key is used. This ensures correct delivery based on storage backend.
* Updated documentation comments in `JobReconciliationService.ts` to clarify the new routing behavior for video completion messages.

**Versioning:**

* Bumped the package version in `package.json` from `2.0.1` to `2.0.2` to reflect these changes.