### PR TITLE
Fix scheduler condition matching for S3 videos

### DIFF
--- a/docs/rule-guide.md
+++ b/docs/rule-guide.md
@@ -32,6 +32,10 @@ the audio file. read [the code](src/utils/Runtime/AudioStream.ts) to see all met
 5. You can use `video_container.getContainerInfo()`, `video_container.getDefaultVideoStreamInfo()`, `video_container.getDefaultAudioStreamInfo` to
 get information about container, video stream and audio stream, but instead of using dot operator, you have to use index operator
 with property name to get the properties of these info. like `video_container.getContainerInfo()['Duration']`
+
+Conditions that reference `video_container`, `video_stream`, or `audio_stream` require the scheduler to download the video to a
+temporary local file. The file is reused while matching rules for that message and removed after rule selection. Conditions that
+only reference `video_filename` or `other_filenames` do not download the video.
    
 ## Actions
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "mira-video-manager",
-   "version": "2.0.2",
+   "version": "2.0.4",
    "description": "Video Process for mira project",
    "main": "index.js",
    "scripts": {

--- a/src/JobScheduler.ts
+++ b/src/JobScheduler.ts
@@ -34,6 +34,7 @@ import {
     JOB_EXCHANGE,
     JOB_QUEUE, MQMessage,
     RabbitMQService,
+    RemoteFile,
     Sentry,
     TYPES,
     VIDEO_MANAGER_COMMAND,
@@ -148,31 +149,47 @@ export class JobScheduler implements JobApplication {
     }
 
     private async onDownloadMessage(msg: DownloadMQMessage): Promise<void> {
-        let appliedRule: VideoProcessRule;
+        let appliedRule: VideoProcessRule = null;
+        let conditionVideoFilePromise: Promise<RemoteFile>;
+        let conditionVideoFileDownloadStarted = false;
+        const conditionCheckId = randomUUID();
+        const getConditionVideoFile = (): Promise<RemoteFile> => {
+            if (!conditionVideoFilePromise) {
+                conditionVideoFileDownloadStarted = true;
+                conditionVideoFilePromise = this.downloadConditionVideoFile(msg, conditionCheckId);
+            }
+            return conditionVideoFilePromise;
+        };
         const rules = await this._databaseService.getVideoProcessRuleRepository().findByBangumiId(msg.bangumiId);
 
-        if (rules && rules.length > 0) {
-            if (rules.length === 1 && rules[0].condition === null && (!rules[0].videoFileId || rules[0].videoFileId === msg.videoId)) {
-                appliedRule = rules[0];
-            } else {
-                // take the first matched condition as the rule is already returned as higher priority first.
-                for (const rule of rules) {
-                    if (rule.videoFileId && msg.videoId && rule.videoFileId === msg.videoId) {
-                        appliedRule = rule;
-                        break;
-                    }
-                }
-                if (!appliedRule) {
-                    // check all bangumi wide rule, we need to exclude video file specified rules
-                    // since checkConditionMatch will return true for any rule.condition is none
-                    // see: https://github.com/irohalab/mira-video-manager/issues/57
+        try {
+            if (rules && rules.length > 0) {
+                if (rules.length === 1 && rules[0].condition === null && (!rules[0].videoFileId || rules[0].videoFileId === msg.videoId)) {
+                    appliedRule = rules[0];
+                } else {
+                    // take the first matched condition as the rule is already returned as higher priority first.
                     for (const rule of rules) {
-                        if (!rule.videoFileId && await this.checkConditionMatch(rule.condition, msg)) {
+                        if (rule.videoFileId && msg.videoId && rule.videoFileId === msg.videoId) {
                             appliedRule = rule;
                             break;
                         }
                     }
+                    if (!appliedRule) {
+                        // check all bangumi wide rule, we need to exclude video file specified rules
+                        // since checkConditionMatch will return true for any rule.condition is none
+                        // see: https://github.com/irohalab/mira-video-manager/issues/57
+                        for (const rule of rules) {
+                            if (!rule.videoFileId && await this.checkConditionMatch(rule.condition, msg, getConditionVideoFile)) {
+                                appliedRule = rule;
+                                break;
+                            }
+                        }
+                    }
                 }
+            }
+        } finally {
+            if (conditionVideoFileDownloadStarted) {
+                await this._fileManageService.cleanUpFiles(conditionCheckId);
             }
         }
 
@@ -205,21 +222,35 @@ export class JobScheduler implements JobApplication {
         return true;
     }
 
-    private async checkConditionMatch(condition: string, msg: DownloadMQMessage): Promise<boolean> {
+    private async checkConditionMatch(condition: string,
+                                      msg: DownloadMQMessage,
+                                      getConditionVideoFile: () => Promise<RemoteFile>): Promise<boolean> {
         if (!condition) {
             return true;
         }
-        const videoFile = this._fileManageService.getFileUrlOrLocalPath(msg.videoFile, msg.downloadManagerId);
-        const otherFiles = msg.otherFiles.map(f => this._fileManageService.getFileUrlOrLocalPath(f, msg.downloadManagerId));
-        const conditionParser = new ConditionParser(condition, videoFile, otherFiles);
         try {
+            let conditionParser = new ConditionParser(condition, msg.videoFile, msg.otherFiles);
             await conditionParser.tokenCheck();
+            if (ConditionParser.requiresVideoInfo(condition)) {
+                conditionParser = new ConditionParser(condition, await getConditionVideoFile(), msg.otherFiles);
+            }
             return await conditionParser.evaluate();
         } catch (e) {
             logger.error(e);
             this._sentry.capture(e);
             return false;
         }
+    }
+
+    private async downloadConditionVideoFile(msg: DownloadMQMessage, conditionCheckId: string): Promise<RemoteFile> {
+        const videoFile = new RemoteFile();
+        videoFile.filename = msg.videoFile.filename;
+        videoFile.fileLocalPath = await this._fileManageService.downloadFile(
+            msg.videoFile,
+            msg.downloadManagerId,
+            conditionCheckId
+        );
+        return videoFile;
     }
 
     /**

--- a/src/services/FileManageService.spec.ts
+++ b/src/services/FileManageService.spec.ts
@@ -74,4 +74,39 @@ test('test download locally', async (t) => {
     t.true(await fileManager.checkExists(testVideoFilename, messageId));
 });
 
+test('preserve S3 URI when an application host mapping exists', t => {
+    const context = t.context as Cx;
+    const fileManager = context.container.get<FileManageService>(FileManageService);
+    const remoteFile = new RemoteFile();
+    remoteFile.filename = testVideoFilename;
+    remoteFile.fileUri = 's3://internal-download-files/path/to/test-video-1.mp4';
+
+    const convertedRemoteFile = fileManager.getFileUrlOrLocalPath(remoteFile, 'test_instance');
+
+    t.is(convertedRemoteFile.fileUri, remoteFile.fileUri);
+});
+
+test('download S3 URI through S3 service', async t => {
+    const context = t.context as Cx;
+    const configManager = context.container.get<ConfigManager>(TYPES.ConfigManager);
+    const sentry = context.container.get<Sentry>(TYPES.Sentry);
+    let downloadedUri: string;
+    const s3Service = {
+        download: async (uri: string, destPath: string) => {
+            downloadedUri = uri;
+            await writeFile(destPath, 'video');
+        }
+    };
+    const fileManager = new FileManageService(configManager, s3Service as any, sentry);
+    const messageId = uuid4();
+    const remoteFile = new RemoteFile();
+    remoteFile.filename = testVideoFilename;
+    remoteFile.fileUri = 's3://internal-download-files/path/to/test-video-1.mp4';
+
+    await fileManager.downloadFile(remoteFile, 'test_instance', messageId);
+
+    t.is(downloadedUri, remoteFile.fileUri);
+    t.true(await fileManager.checkExists(testVideoFilename, messageId));
+});
+
 // TODO: write test download from network.

--- a/src/services/FileManageService.ts
+++ b/src/services/FileManageService.ts
@@ -59,6 +59,10 @@ export class FileManageService {
         const host = appId ? idHostMap[appId]: null;
         const convertedRemoteFile =  new RemoteFile();
         convertedRemoteFile.filename = remoteFile.filename;
+        if (FileManageService.isS3Url(remoteFile.fileUri)) {
+            convertedRemoteFile.fileUri = remoteFile.fileUri;
+            return convertedRemoteFile;
+        }
         if (host) {
             const hostURLObj = new URL(host);
             if (hostURLObj.hostname === 'localhost') {

--- a/src/services/JobScheduler.spec.ts
+++ b/src/services/JobScheduler.spec.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 IROHA LAB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import test from 'ava';
+import 'reflect-metadata';
+import { join } from 'path';
+import { DownloadMQMessage, RemoteFile } from '@irohalab/mira-shared';
+import { JobScheduler } from '../JobScheduler';
+import { VideoProcessRule } from '../entity/VideoProcessRule';
+import { JobType } from '../domains/JobType';
+
+test('reuse and clean up a local video while matching metadata rules', async t => {
+    const selectedActions = {selected: {}} as any;
+    const firstRule = new VideoProcessRule();
+    firstRule.condition = 'video_container.videoStreamCount() === 99';
+    firstRule.actions = {};
+    const secondRule = new VideoProcessRule();
+    secondRule.condition = 'video_container.videoStreamCount() > 0';
+    secondRule.actions = selectedActions;
+    const savedJobs = [];
+    const publishedMessages = [];
+    let downloadCount = 0;
+    let cleanupCount = 0;
+    let downloadMessageId: string;
+    let cleanupMessageId: string;
+    const databaseService = {
+        getVideoProcessRuleRepository: () => ({
+            findByBangumiId: async () => [firstRule, secondRule]
+        }),
+        getJobRepository: () => ({
+            save: async job => savedJobs.push(job)
+        })
+    };
+    const fileManageService = {
+        downloadFile: async (_remoteFile, _appId, messageId) => {
+            downloadCount++;
+            downloadMessageId = messageId;
+            return join(__dirname, '../../tests/test-video-1.mp4');
+        },
+        cleanUpFiles: async messageId => {
+            cleanupCount++;
+            cleanupMessageId = messageId;
+        }
+    };
+    const rabbitmqService = {
+        publish: async (_exchange, _key, message) => {
+            publishedMessages.push(message);
+        }
+    };
+    const scheduler = new JobScheduler(
+        {} as any,
+        databaseService as any,
+        {capture: () => undefined} as any,
+        fileManageService as any,
+        rabbitmqService as any
+    );
+    const message = new DownloadMQMessage();
+    message.id = 'download-message';
+    message.bangumiId = 'bangumi';
+    message.downloadManagerId = 'download-manager';
+    message.videoId = 'video';
+    message.videoFile = new RemoteFile();
+    message.videoFile.filename = 'test-video-1.mp4';
+    message.videoFile.fileUri = 's3://internal-download-files/test-video-1.mp4';
+    message.otherFiles = [];
+
+    await (scheduler as any).onDownloadMessage(message);
+
+    t.is(downloadCount, 1);
+    t.is(cleanupCount, 1);
+    t.is(cleanupMessageId, downloadMessageId);
+    t.is(savedJobs.length, 1);
+    t.is(savedJobs[0].jobMessage.jobType, JobType.NORMAL_JOB);
+    t.is(savedJobs[0].jobMessage.actions, selectedActions);
+    t.is(publishedMessages.length, 1);
+});

--- a/src/utils/ConditionParser.spec.ts
+++ b/src/utils/ConditionParser.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 IROHA LAB
+ * Copyright 2026 IROHA LAB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,37 @@
 
 import test from 'ava';
 import 'reflect-metadata';
+import { RemoteFile } from '@irohalab/mira-shared';
 import { ConditionParser } from './ConditionParser';
 
 test('detect invalid identifier, keyword and punctuator', t => {
     const conditionParser = new ConditionParser('bash ls', null, null);
     t.throws(conditionParser.tokenCheck);
+});
+
+test('identify conditions that require video info', t => {
+    t.false(ConditionParser.requiresVideoInfo('video_filename.includes("[Nix-Raws]")'));
+    t.false(ConditionParser.requiresVideoInfo('other_filenames.includes("subtitle.ass")'));
+    t.true(ConditionParser.requiresVideoInfo('video_container.videoStreamCount() > 0'));
+    t.true(ConditionParser.requiresVideoInfo('video_stream.getWidth() >= 1920'));
+    t.true(ConditionParser.requiresVideoInfo('audio_stream.isPlayable()'));
+});
+
+test('evaluate filename-only conditions without probing the video', async t => {
+    const videoFile = new RemoteFile();
+    videoFile.filename = '[Nix-Raws] Tenkousaki no Seiso Karen na Bishoujo ga Mukashi Danshi to Omotte Issho ni Asonda Osananajimi datta Ken S01E05 [CR WEB-DL 1080p AVC AAC][SC_TC].mkv';
+    videoFile.fileLocalPath = '/nonexistent/video.mkv';
+    const conditions = [
+        'video_filename.includes("[SubsPlease]")',
+        'video_filename.includes("[Nix-Raws]")'
+    ];
+    const matches = [];
+
+    for (const condition of conditions) {
+        const conditionParser = new ConditionParser(condition, videoFile, []);
+        conditionParser.tokenCheck();
+        matches.push(await conditionParser.evaluate());
+    }
+
+    t.deepEqual(matches, [false, true]);
 });

--- a/src/utils/ConditionParser.ts
+++ b/src/utils/ConditionParser.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 IROHA LAB
+ * Copyright 2026 IROHA LAB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ const ID_OTHER_FILENAMES = 'other_filenames';
 const ID_VIDEO_CONTAINER = 'video_container';
 const ID_VIDEO_STREAM = 'video_stream';
 const ID_AUDIO_STREAM = 'audio_stream';
+const VIDEO_INFO_IDENTIFIERS = [ID_VIDEO_CONTAINER, ID_VIDEO_STREAM, ID_AUDIO_STREAM];
 
 const TOKEN_TYPE = {
     Punctuator: 'Punctuator',
@@ -71,6 +72,14 @@ export class ConditionParser {
 
     }
 
+    public static requiresVideoInfo(condition: string): boolean {
+        if (!condition) {
+            return false;
+        }
+        const tokens = tokenize(condition) as Token[];
+        return tokens.some(token => token.type === TOKEN_TYPE.Identifier && VIDEO_INFO_IDENTIFIERS.includes(token.value));
+    }
+
     public tokenCheck(): void {
         const tokens = tokenize(this._condition, {range: true}) as Token[];
         for(const token of tokens) {
@@ -102,7 +111,9 @@ export class ConditionParser {
             basename,
             extname
         };
-        await this.getVideoInfo(sandbox);
+        if (ConditionParser.requiresVideoInfo(this._condition)) {
+            await this.getVideoInfo(sandbox);
+        }
         vm.createContext(sandbox);
         return vm.runInContext(this._condition, sandbox);
     }


### PR DESCRIPTION
## Summary

- skip media probing for rules that only inspect video or companion filenames
- preserve `s3://` source URIs and download videos locally only when media metadata is required
- reuse the temporary video across rule checks and remove it after rule selection
- document the metadata-condition download behavior and bump the release version to 2.0.4

## Testing

- `npm test -- src/utils/ConditionParser.spec.ts src/services/FileManageService.spec.ts`
- `npm exec tsc -- --noEmit`

Fixes #96